### PR TITLE
add the missed parameter flags in sched_setattr macro

### DIFF
--- a/syscall_magic.h
+++ b/syscall_magic.h
@@ -76,4 +76,4 @@ struct sched_attr {
 	syscall(__NR_sched_getattr, pid, attr, size, flags)
 
 #define sched_setattr(pid, attr, flags) \
-	syscall(__NR_sched_setattr, pid, attr)
+	syscall(__NR_sched_setattr, pid, attr, flags)


### PR DESCRIPTION
Signed-off-by: Wang Long long.wanglong@huawei.com
